### PR TITLE
rstudio server commands to waldronlab/bioconductor

### DIFF
--- a/waldronlab/bioconductor.yaml
+++ b/waldronlab/bioconductor.yaml
@@ -10,3 +10,8 @@ manifest:
     docker_image: bioconductor/bioconductor_full:devel
     docker_command: R
     dockerargs: "-it"
+  - command: rstudio-server
+    docker_image: bioconductor/bioconductor_full:release
+  - command: rstudio-server-dev
+    docker_image: bioconductor/bioconductor_full:devel
+    docker_command: rstudio-server


### PR DESCRIPTION
Doing this as a PR because I'm not sure it really works. I've also added `-p` and `-e` arguments to my `bulker_config.yaml`, ie::

```
28c28
<           docker_args: --volume=${HOME}/R/bioc-release:/usr/local/lib/R/host-site-library
---
>           docker_args: --volume=${HOME}/R/bioc-release:/usr/local/lib/R/host-site-library -e PASSWORD=rstudiopassword -p 8787:8787
30c30
<           docker_args: --volume=${HOME}/R/bioc-devel:/usr/local/lib/R/host-site-library
---
>           docker_args: --volume=${HOME}/R/bioc-devel:/usr/local/lib/R/host-site-library -e PASSWORD=rstudiopassword -p 8787:8788
```

Then I load & activate this new waldronlab/bioconductor crate, and do:

```
bulker-3.2$ rstudio-server start
WARNING: Published ports are discarded when using host network mode
bulker-3.2$ 
```

I can see that it indeed launched a container:
```
Levis-MBP:~ lwaldron$ docker ps
CONTAINER ID        IMAGE                                    COMMAND                  CREATED             STATUS              PORTS               NAMES
51073b568e0e        bioconductor/bioconductor_full:release   "rstudio-server start"   26 minutes ago      Up 26 minutes                           ecstatic_lichterman
f2
```

Navigating to `http://localhost:8787` however gives me an "Unable to connect" error. In contrast, if I do for example the following (within or without bulker):

```
docker run                                      \
      -e PASSWORD=your_password                   \
      -p 8787:8787                                \
      bioconductor/bioconductor_full:release
```

then the server can be found on localhost:8787 and I see the following from `docker ps`:
```
CONTAINER ID        IMAGE                                    COMMAND                  CREATED             STATUS              PORTS                    NAMES
28f01cc4a5ea        bioconductor/bioconductor_full:release   "/init"                  6 seconds ago       Up 4 seconds        0.0.0.0:8787->8787/tcp   relaxed_wilson
```

I did also try putting `docker_command: /init` or `docker_command: " "` in my bioconductor manifest, but that produced an additional warning, did not launch an image visible by `docker ps`, or start listening on on localhost:8787:

```
bulker-3.2$ rstudio-server
WARNING: Published ports are discarded when using host network mode
s6-mkdir: warning: unable to mkdir /var/run/s6: Permission denied
```

So I am at a loss of what to try next...