### PR TITLE
Update waldronlab bioconductor.yaml to 3.18

### DIFF
--- a/waldronlab/bioconductor.yaml
+++ b/waldronlab/bioconductor.yaml
@@ -1,23 +1,23 @@
 manifest:
   name: bioconductor
-  version: 3.17
+  version: 3.18
   commands:
   - command: R
-    docker_image: bioconductor/bioconductor_docker:RELEASE_3_17
+    docker_image: bioconductor/bioconductor_docker:RELEASE_3_18
     docker_args: "-it"
   - command: Rdev
     docker_image: bioconductor/bioconductor_docker:devel
     docker_command: R
     docker_args: "-it"
   - command: Rscript
-    docker_image: bioconductor/bioconductor_docker:RELEASE_3_17
+    docker_image: bioconductor/bioconductor_docker:RELEASE_3_18
     docker_args: "-it"
   - command: Rscriptdev
     docker_image: bioconductor/bioconductor_docker:devel
     docker_command: Rscript
     docker_args: "-it"
   - command: rstudioserver
-    docker_image: bioconductor/bioconductor_docker:RELEASE_3_17
+    docker_image: bioconductor/bioconductor_docker:RELEASE_3_18
     docker_command: " "
     no_user: True
     no_network: True


### PR DESCRIPTION
I'd like to update the Waldron lab's Bioconductor bulker crate to use Bioconductor 3.18.