### PR TITLE
add pepatac 1.0.13 manifest

### DIFF
--- a/databio/pepatac_1.0.13.yaml
+++ b/databio/pepatac_1.0.13.yaml
@@ -15,13 +15,13 @@ manifest:
     docker_args: "-i"
   - command: bedtools
     docker_args: "-i"
-    docker_image: quay.io/biocontainers/bedtools:2.30.0--h468198e_3
+    docker_image: quay.io/biocontainers/bedtools:2.31.1--hf5e1c6e_1
   - command: bowtie2
-    docker_image: quay.io/biocontainers/bowtie2:2.5.0--py38h77f66f0_0
+    docker_image: quay.io/biocontainers/bowtie2:2.5.4--he20e202_1
   - command: bwa
     docker_image: quay.io/biocontainers/bwa:0.7.17--h7132678_9
   - command: fastqc
-    docker_image: quay.io/biocontainers/fastqc:0.11.9--0
+    docker_image: quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0
   - command: findPeaks
     docker_image: quay.io/biocontainers/homer:4.11--pl5321h9f5acd7_7
   - command: findMotifsGenome.pl
@@ -36,9 +36,9 @@ manifest:
     docker_image: openjdk
     docker_args: "-i"
   - command: macs3
-    docker_image: quay.io/biocontainers/macs3:3.0.2--py312he57d009_1
+    docker_image: quay.io/biocontainers/macs3:3.0.1--py310h83093d7_1
   - command: picard
-    docker_image: quay.io/biocontainers/picard:2.27.4--hdfd78af_0
+    docker_image: quay.io/biocontainers/picard:2.27.5--hdfd78af_0
   - command: pigz
     docker_image: nsheff/pigz
   - command: preseq
@@ -53,7 +53,7 @@ manifest:
     docker_args: "-i"
   - command: samtools
     docker_args: "-i"
-    docker_image: quay.io/biocontainers/samtools:1.16.1--h6899075_1
+    docker_image: quay.io/biocontainers/samtools:1.21--h96c455f_1
   - command: seqOutBias
     docker_image: databio/seqoutbias:0.0.1
   - command: skewer

--- a/databio/pepatac_1.0.13.yaml
+++ b/databio/pepatac_1.0.13.yaml
@@ -1,0 +1,63 @@
+manifest:
+  name: pepatac
+  version: 1.0.13
+  imports:
+  - bulker/alpine:default
+  - bulker/coreutils:default
+  host_commands:
+  - python3
+  - perl
+  commands:
+  - command: bedGraphToBigWig
+    docker_image: quay.io/biocontainers/ucsc-bedgraphtobigwig:357--h35c10e6_3 
+  - command: bedToBigBed
+    docker_image: quay.io/biocontainers/ucsc-bedtobigbed:357--1
+    docker_args: "-i"
+  - command: bedtools
+    docker_args: "-i"
+    docker_image: quay.io/biocontainers/bedtools:2.30.0--h468198e_3
+  - command: bowtie2
+    docker_image: quay.io/biocontainers/bowtie2:2.5.0--py38h77f66f0_0
+  - command: bwa
+    docker_image: quay.io/biocontainers/bwa:0.7.17--h7132678_9
+  - command: fastqc
+    docker_image: quay.io/biocontainers/fastqc:0.11.9--0
+  - command: findPeaks
+    docker_image: quay.io/biocontainers/homer:4.11--pl5321h9f5acd7_7
+  - command: findMotifsGenome.pl
+    docker_image: quay.io/biocontainers/homer:4.11--pl5321h9f5acd7_7
+  - command: fseq
+    docker_image: quay.io/biocontainers/fseq:1.84--py35pl5.22.0_0
+  - command: Genrich
+    docker_image: quay.io/biocontainers/genrich:0.6.1--h7132678_2
+  - command: hmmratac
+    docker_image: quay.io/biocontainers/hmmratac:1.2.10--hdfd78af_1
+  - command: java
+    docker_image: openjdk
+    docker_args: "-i"
+  - command: macs3
+    docker_image: quay.io/biocontainers/macs3:3.0.2--py312he57d009_1
+  - command: picard
+    docker_image: quay.io/biocontainers/picard:2.27.4--hdfd78af_0
+  - command: pigz
+    docker_image: nsheff/pigz
+  - command: preseq
+    docker_image: quay.io/biocontainers/preseq:2.0.3--h26b358d_2
+  - command: R
+    docker_image: databio/rpipe:0.3.1
+    docker_command: R
+  - command: Rscript
+    docker_image: databio/rpipe:0.3.1
+  - command: samblaster
+    docker_image: quay.io/biocontainers/samblaster:0.1.26--h9f5acd7_2
+    docker_args: "-i"
+  - command: samtools
+    docker_args: "-i"
+    docker_image: quay.io/biocontainers/samtools:1.16.1--h6899075_1
+  - command: seqOutBias
+    docker_image: databio/seqoutbias:0.0.1
+  - command: skewer
+    docker_image: quay.io/biocontainers/skewer:0.2.2--hc9558a2_3
+  - command: trimmomatic
+    docker_image: quay.io/biocontainers/trimmomatic:0.39--hdfd78af_2
+


### PR DESCRIPTION
I would also like to update the pepatac package versions to match what we have in the detailed install section:
https://github.com/databio/pepatac/blob/dev/docs/detailed-install.md

However, there are usually more than one of the same version with different build hashes, and it was not clear to me how to select one as the metadata on quay.io was identical.
